### PR TITLE
Update to run with parenttext_core

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,18 +1,10 @@
+from parenttext_core.config import core_spreadsheet_ids
+
 # Data sources, ids of google sheets where the core date is stored, 
 localised_sheets = "13do_Qnc0VKC6Ao4N7YY3skUFKJMuwOixj2GyMVwnRLM" #specific for ZA
 
-# shared with all deployments
-T_C_onboarding_ID = "12ddvTz_ZfC-9-b0yxjVrSzczciUUE3GosLUFeOLIv9I"
-T_content_ID = "1hcH8pFdiHZN0UvZgyv3Zht9ARBTx-VXhNBI2o8L7fHU" #multiple content index for different types of content
-C_ltp_activities_ID = "1Jx7vOmdefzK62ao2nlJJVLMAIS8d-6r1G8qn0jG8gww"
-T_delivery_ID = "1yf6T8FsNF5SIS7ktj05Wj7ha_Hkfrf66r63kfUWhJbI"
-C_modules_teen_ID = "1ONmD9PF9rcno3ha3QpfrIR5EIvHuuEqJXF3T90rlZ78"
-C_dictionaries_ID = "1uc4WOOlyHTEV8fUGb8nPCYcPj446TRtsV8fucrOCxC4"
-C_home_activity_checkin_ID = "1qjjM2XfkvGVk38GL2OASNkTrXyXuDMAuMUAKmgHYt_s"
-T_C_menu_ID = "1lf80mIiuv_F6xAa9j5zGvXas50WxdSsLj6vrPccGNwY"
-C_goal_checkin_ID = "1gympuD5KdlAdDJSuaVQiXjWSwJxoDcA9K-oBRyKmS7o"
-C_dev_asess_tool_ID = "1OhhQF5yarUDmaSl2tlt7eIT7wJ8bGwNFzI3BOplJYsc"
-safeguarding = "1PHgUhJnZdE0lK6C9teK-hwA6Tf-6Pgj1_OVdxoTgVOA"
+all_spreadsheet_ids = core_spreadsheet_ids
+all_spreadsheet_ids.append(localised_sheets)
 
 # "filename" is how it will be generally named in the pipeline.
 # "crowdin_name" will be the name of the file that is produced to send to the translators
@@ -20,7 +12,7 @@ safeguarding = "1PHgUhJnZdE0lK6C9teK-hwA6Tf-6Pgj1_OVdxoTgVOA"
 # "split_no" is used to divide the file at the final step to get it to a manageable size that can be uploaded to rapidpro
 sources = [
     {"filename": "parenttext_all",
-     "spreadsheet_ids": [localised_sheets, T_C_onboarding_ID, C_ltp_activities_ID, T_delivery_ID, C_modules_teen_ID, C_dictionaries_ID, C_home_activity_checkin_ID, T_C_menu_ID, C_goal_checkin_ID, T_content_ID,C_dev_asess_tool_ID, safeguarding], 
+     "spreadsheet_ids": all_spreadsheet_ids, 
      "crowdin_name": "text_for_translators",
      # possible values for tag 1: onboarding dev_assess ltp_activity home_activity_checkin module goal_checkin safeguarding menu delivery
      #"tags": [1, "delivery",1, "menu", 2,"south_africa"],
@@ -73,11 +65,9 @@ count_threshold = "3"
 length_threshold = "18"
 
 #Google sheet ID containing ab testing data
-ab_testing_sheet_ID = "1i_oqiJYkeoMsYdeFOcKlvvjnNCEdQnZlsm17fgNvK0s" #same for all deployments
 localisation_sheet_ID = "1FfO-LLjodgEKaBVnn47QrvXaM68Cvui55FS1DKziA2c" #south africa specific
 
 #Google sheet ID containing dict edits data
-eng_edits_sheet_ID = "1Ab8H_s26EuOiS4nZ6HGADjD4CZw55586LL66fl8tEWI" #same for all deployments
 transl_edits_sheet_ID = "1fCLPfiqHy1nLLqh1qyvd3zrziw5Tz3uQ6_e7CyuEW-E" #south africa specific
 
 #Data used in safeguarding script

--- a/produce_flows.py
+++ b/produce_flows.py
@@ -6,6 +6,7 @@ import sys
 # leave in place for now, above code enables quick local testing
 
 from parenttext_pipeline.pipelines import run_pipeline
+from parenttext_core.config import core_spreadsheet_ids, ab_testing_sheet_ID, eng_edits_sheet_ID
 from config import *
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 parenttext_pipeline@https://github.com/IDEMSInternational/parenttext-pipeline/archive/refs/heads/main.tar.gz
+parenttext_core@https://github.com/IDEMSInternational/parenttext-core/archive/refs/heads/main.tar.gz
+
 


### PR DESCRIPTION
@fagiothree @istride have split out the parts of the config file that are generic into 'parenttext-core' and am importing them as a package. General thoughts whether this approach is reasonable or if we should do something else